### PR TITLE
Fix renames on Windows (<go1.5) and Plan 9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # safefile
 
-[![Build Status](https://travis-ci.org/dchest/safefile.svg)](https://travis-ci.org/dchest/safefile)
+[![Build Status](https://travis-ci.org/dchest/safefile.svg)](https://travis-ci.org/dchest/safefile) [![Windows Build status](https://ci.appveyor.com/api/projects/status/owlifxeekg75t2ho?svg=true)](https://ci.appveyor.com/project/dchest/safefile)
 
 Go package safefile implements safe "atomic" saving of files.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\projects\src\github.com\dchest\safefile
+
+environment:
+ PATH: c:\projects\bin;%PATH%
+ GOPATH: c:\projects
+ NOTIFY_TIMEOUT: 5s
+
+install:
+ - go version
+ - go get golang.org/x/tools/cmd/vet
+ - go get -v -t ./...
+
+build_script:
+ - go tool vet -all .
+ - go build ./...
+ - go test -v -race ./...
+
+test: off
+
+deploy: off

--- a/rename.go
+++ b/rename.go
@@ -1,4 +1,4 @@
-// +build !plan9 windows,go1.5
+// +build !plan9,!windows windows,go1.5
 
 package safefile
 

--- a/rename.go
+++ b/rename.go
@@ -1,4 +1,4 @@
-// +build !plan9 !windows,!go1.5
+// +build !plan9 windows,go1.5
 
 package safefile
 

--- a/rename.go
+++ b/rename.go
@@ -1,0 +1,9 @@
+// +build !plan9 !windows,!go1.5
+
+package safefile
+
+import "os"
+
+func rename(oldname, newname string) error {
+	return os.Rename(oldname, newname)
+}

--- a/rename_nonatomic.go
+++ b/rename_nonatomic.go
@@ -27,7 +27,7 @@ func rename(oldname, newname string) error {
 			if err != nil {
 				return err
 			}
-			err = os.Stat(origtmp)
+			_, err = os.Stat(origtmp)
 			if err == nil {
 				continue // most likely will never happen
 			}

--- a/rename_nonatomic.go
+++ b/rename_nonatomic.go
@@ -23,7 +23,10 @@ func rename(oldname, newname string) error {
 		// temporary name is not known.)
 		var origtmp string
 		for {
-			origtmp = makeTempName(newname, filepath.Base(newname))
+			origtmp, err = makeTempName(newname, filepath.Base(newname))
+			if err != nil {
+				return err
+			}
 			err = os.Stat(origtmp)
 			if err == nil {
 				continue // most likely will never happen

--- a/rename_nonatomic.go
+++ b/rename_nonatomic.go
@@ -1,0 +1,48 @@
+// +build plan9 windows,!go1.5
+
+// os.Rename on Windows before Go 1.5 and Plan 9 will not overwrite existing
+// files, thus we cannot guarantee atomic saving of file by doing rename.
+// We will have to do some voodoo to minimize data loss on those systems.
+
+package safefile
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func rename(oldname, newname string) error {
+	err := os.Rename(oldname, newname)
+	if err != nil {
+		// If newname exists ("original"), we will try renaming it to a
+		// new temporary name, then renaming oldname to the newname,
+		// and deleting the renamed original. If system crashes between
+		// renaming and deleting, the original file will still be available
+		// under the temporary name, so users can manually recover data.
+		// (No automatic recovery is possible because after crash the
+		// temporary name is not known.)
+		var origtmp string
+		for {
+			origtmp = makeTempName(newname, filepath.Base(newname))
+			err = os.Stat(origtmp)
+			if err == nil {
+				continue // most likely will never happen
+			}
+			break
+		}
+		err = os.Rename(newname, origtmp)
+		if err != nil {
+			return err
+		}
+		err = os.Rename(oldname, newname)
+		if err != nil {
+			// Rename still fails, try to revert original rename,
+			// ignoring errors.
+			os.Rename(origtmp, newname)
+			return err
+		}
+		// Rename succeeded, now delete original file.
+		os.Remove(origtmp)
+	}
+	return nil
+}

--- a/safefile.go
+++ b/safefile.go
@@ -66,7 +66,7 @@ func makeTempName(origname, prefix string) (tempname string, err error) {
 	if _, err := rand.Read(rnd[:]); err != nil {
 		return "", err
 	}
-	name := prefix + strings.ToLower(base32.StdEncoding.EncodeToString(rnd[:])) + ".tmp"
+	name := prefix + "-" + strings.ToLower(base32.StdEncoding.EncodeToString(rnd[:])) + ".tmp"
 	return filepath.Join(filepath.Dir(origname), name), nil
 }
 
@@ -74,7 +74,7 @@ func makeTempName(origname, prefix string) (tempname string, err error) {
 // which will be renamed to the given filename when calling Commit.
 func Create(filename string, perm os.FileMode) (*File, error) {
 	for {
-		tempname, err := makeTempName(filename, "sf-")
+		tempname, err := makeTempName(filename, "sf")
 		if err != nil {
 			return nil, err
 		}

--- a/safefile.go
+++ b/safefile.go
@@ -54,7 +54,7 @@ type File struct {
 	isCommitted bool // if true, the file has been successfully committed
 }
 
-func makeTempName(origname string) (tempname string, err error) {
+func makeTempName(origname, prefix string) (tempname string, err error) {
 	origname = filepath.Clean(origname)
 	if len(origname) == 0 || origname[len(origname)-1] == filepath.Separator {
 		return "", os.ErrInvalid
@@ -66,7 +66,7 @@ func makeTempName(origname string) (tempname string, err error) {
 	if _, err := rand.Read(rnd[:]); err != nil {
 		return "", err
 	}
-	name := "sf-" + strings.ToLower(base32.StdEncoding.EncodeToString(rnd[:])) + ".tmp"
+	name := prefix + strings.ToLower(base32.StdEncoding.EncodeToString(rnd[:])) + ".tmp"
 	return filepath.Join(filepath.Dir(origname), name), nil
 }
 
@@ -74,7 +74,7 @@ func makeTempName(origname string) (tempname string, err error) {
 // which will be renamed to the given filename when calling Commit.
 func Create(filename string, perm os.FileMode) (*File, error) {
 	for {
-		tempname, err := makeTempName(filename)
+		tempname, err := makeTempName(filename, "sf-")
 		if err != nil {
 			return nil, err
 		}
@@ -168,7 +168,7 @@ func (f *File) Commit() error {
 		f.isClosed = true
 	}
 	// Rename.
-	err := os.Rename(f.Name(), f.origName)
+	err := rename(f.Name(), f.origName)
 	if err != nil {
 		f.closeFunc = closeAfterFailedRename
 		return err

--- a/safefile_test.go
+++ b/safefile_test.go
@@ -59,7 +59,7 @@ func TestMakeTempName(t *testing.T) {
 	// Make sure temp name is random.
 	m := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		name, err := makeTempName("/tmp", "sf-")
+		name, err := makeTempName("/tmp", "sf")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/safefile_test.go
+++ b/safefile_test.go
@@ -73,7 +73,7 @@ func TestMakeTempName(t *testing.T) {
 func TestFile(t *testing.T) {
 	err := testInTempDir()
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatal(err)
 	}
 }
 
@@ -81,21 +81,21 @@ func TestWriteFile(t *testing.T) {
 	name := tempFileName(1)
 	err := WriteFile(name, []byte(testData), 0666)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatal(err)
 	}
 	err = ensureFileContains(name, testData)
 	if err != nil {
 		os.Remove(name)
-		t.Fatalf("%s", err)
+		t.Fatal(err)
 	}
 	os.Remove(name)
 }
 
 func TestAbandon(t *testing.T) {
-	name := tempFileName(3)
+	name := tempFileName(2)
 	f, err := Create(name, 0666)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatal(err)
 	}
 	err = f.Close()
 	if err != nil {
@@ -104,7 +104,7 @@ func TestAbandon(t *testing.T) {
 	// Make sure temporary file doesn't exist.
 	_, err = os.Stat(f.Name())
 	if err != nil && !os.IsNotExist(err) {
-		t.Fatalf("%s", err)
+		t.Fatal(err)
 	}
 }
 
@@ -112,7 +112,7 @@ func TestDoubleCommit(t *testing.T) {
 	name := tempFileName(3)
 	f, err := Create(name, 0666)
 	if err != nil {
-		t.Fatalf("%s", err)
+		t.Fatal(err)
 	}
 	err = f.Commit()
 	if err != nil {
@@ -130,4 +130,26 @@ func TestDoubleCommit(t *testing.T) {
 		t.Fatalf("Close failed: %s", err)
 	}
 	os.Remove(name)
+}
+
+func TestOverwriting(t *testing.T) {
+	name := tempFileName(4)
+	defer os.Remove(name)
+
+	olddata := "This is old data"
+	err := ioutil.WriteFile(name, []byte(olddata), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newdata := "This is new data"
+	err = WriteFile(name, []byte(newdata), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ensureFileContains(name, newdata)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/safefile_test.go
+++ b/safefile_test.go
@@ -59,7 +59,7 @@ func TestMakeTempName(t *testing.T) {
 	// Make sure temp name is random.
 	m := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		name, err := makeTempName("/tmp")
+		name, err := makeTempName("/tmp", "sf-")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
os.Rename on Windows before Go 1.5 and Plan 9 will not overwrite
existing files, thus we cannot guarantee atomic saving of file by doing
rename. We have to do voodoo to minimize data loss on those systems by
providing our own rename function for such systems, with the following
algorithm:

 rename(OLD, NEW) =

      rename NEW to NEW-xxxx.tmp
      rename OLD to NEW
      delete NEW-xxxx.tmp

If system crashes between renaming and deleting, the original file will
still be available under the temporary name, so users can manually
recover data. (No automatic recovery is possible because after crash the
temporary name is not known.)

Closes #4.